### PR TITLE
Use correct layer for Player collision detection

### DIFF
--- a/Assets/Scripts/HelloWorldPlayer.cs
+++ b/Assets/Scripts/HelloWorldPlayer.cs
@@ -160,7 +160,7 @@ namespace HelloWorld
 					GetComponent<CircleCollider2D>().radius,
 					new Vector3(dir.x, 0, 0),
 					val,
-					LayerMask.GetMask("TestObstacle")
+					LayerMask.GetMask("Wall")
 				).collider != null)
 				dir.x = 0;
 			if (Physics2D.CircleCast(
@@ -168,7 +168,7 @@ namespace HelloWorld
 					GetComponent<CircleCollider2D>().radius,
 					new Vector3(0, dir.y, 0),
 					val,
-					LayerMask.GetMask("TestObstacle")
+					LayerMask.GetMask("Wall")
 				).collider != null)
 				dir.y = 0;
 


### PR DESCRIPTION
Now the layer 'Wall' is used when tracing for collisions.